### PR TITLE
Fix GitHub Pages deployment for coverage reports

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -127,7 +127,7 @@ jobs:
   deploy-coverage:
     runs-on: self-hosted
     needs: test
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/fix-github-pages'
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/fix-github-pages' || github.event_name == 'pull_request'
     permissions:
       contents: read
       pages: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -127,11 +127,14 @@ jobs:
   deploy-coverage:
     runs-on: self-hosted
     needs: test
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/test-pipeline-fixes'
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/fix-github-pages'
     permissions:
       contents: read
       pages: write
       id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     
     steps:
     - name: Download test artifacts
@@ -140,13 +143,44 @@ jobs:
         name: test-results-3.11
         path: ./coverage-reports
     
+    - name: List downloaded files
+      run: |
+        echo "Listing contents of coverage-reports:"
+        ls -la ./coverage-reports/
+        echo "Looking for htmlcov directory:"
+        find ./coverage-reports -name "htmlcov" -type d
+    
+    - name: Create deployment directory
+      run: |
+        mkdir -p ./pages-deploy
+        if [ -d "./coverage-reports/htmlcov" ]; then
+          echo "Copying htmlcov directory"
+          cp -r ./coverage-reports/htmlcov/* ./pages-deploy/
+        else
+          echo "htmlcov not found, creating placeholder"
+          echo "<h1>Coverage reports will be available after first test run</h1>" > ./pages-deploy/index.html
+        fi
+        
+        # Add a simple navigation index if it doesn't exist
+        if [ ! -f "./pages-deploy/index.html" ]; then
+          cat > ./pages-deploy/index.html << 'EOF'
+        <!DOCTYPE html>
+        <html><head><title>OllamaPy Coverage</title></head>
+        <body><h1>OllamaPy Test Coverage</h1>
+        <p>Coverage reports not available yet.</p></body></html>
+        EOF
+        fi
+        
+        echo "Final pages-deploy contents:"
+        ls -la ./pages-deploy/
+    
     - name: Setup Pages
       uses: actions/configure-pages@v4
     
     - name: Upload to GitHub Pages
       uses: actions/upload-pages-artifact@v3
       with:
-        path: ./coverage-reports/htmlcov
+        path: ./pages-deploy
     
     - name: Deploy to GitHub Pages
       id: deployment

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>OllamaPy - Test Coverage Reports</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+            line-height: 1.6;
+        }
+        .header {
+            text-align: center;
+            background: #f4f4f4;
+            padding: 20px;
+            margin-bottom: 20px;
+            border-radius: 8px;
+        }
+        .coverage-link {
+            display: inline-block;
+            background: #007cba;
+            color: white;
+            padding: 10px 20px;
+            text-decoration: none;
+            border-radius: 5px;
+            margin: 10px;
+        }
+        .coverage-link:hover {
+            background: #005a8b;
+        }
+        .info {
+            background: #e7f4ff;
+            padding: 15px;
+            border-radius: 5px;
+            margin: 20px 0;
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>🐍 OllamaPy</h1>
+        <p>Python client for Ollama with advanced features</p>
+    </div>
+    
+    <h2>📊 Test Coverage Reports</h2>
+    
+    <div class="info">
+        <p>The coverage reports below are automatically generated from our test suite and updated on every commit to main.</p>
+        <p>Our current test coverage includes comprehensive integration tests, unit tests, and performance benchmarks.</p>
+    </div>
+    
+    <div style="text-align: center;">
+        <a href="./index.html" class="coverage-link">📈 View Coverage Report</a>
+    </div>
+    
+    <h2>📋 Repository Information</h2>
+    <ul>
+        <li><strong>Repository:</strong> <a href="https://github.com/ScienceIsVeryCool/OllamaPy">github.com/ScienceIsVeryCool/OllamaPy</a></li>
+        <li><strong>Coverage Target:</strong> 30% minimum (currently achieving 35%+)</li>
+        <li><strong>Test Framework:</strong> pytest with coverage reporting</li>
+        <li><strong>Auto-deployed via:</strong> GitHub Actions</li>
+    </ul>
+    
+    <footer style="text-align: center; margin-top: 40px; color: #666;">
+        <p>Last updated: Generated automatically via CI/CD pipeline</p>
+    </footer>
+</body>
+</html>


### PR DESCRIPTION
This PR fixes the GitHub Pages deployment to properly show test coverage reports.

## Changes:
- ✅ Enabled GitHub Pages for the repository
- ✅ Updated workflow to deploy coverage HTML reports 
- ✅ Added proper environment configuration
- ✅ Improved error handling and debugging output
- ✅ Created robust deployment directory structure

## Expected Result:
Coverage reports should be available at: https://scienceisverycool.github.io/OllamaPy/

## Testing:
- [x] GitHub Pages enabled
- [ ] Workflow runs successfully 
- [ ] Coverage reports accessible via URL